### PR TITLE
Updates to package README

### DIFF
--- a/packages/example_model/README.md
+++ b/packages/example_model/README.md
@@ -1,13 +1,45 @@
 # Example model
 
-This python package provides a simple, standalone executable model.
+This python package provides a simple branching process model intended to be used with the `mrp` (model runner protocol) package.
 
-To run the model within the `uv` environment:
+This README will describe multiple ways to run the model.
+
+First open the Python interactive shell within the `uv` environment:
 
 ```bash
 uv sync --all-packages
-uv run python -m example_model.example_model packages/example_model/tests/model_input.json
+uv run python
 ```
+The following two lines of code are sufficient to run the example model using the static method (i.e., calling `Binom_BP_Model.simulate()`).
+```python
+from example_model import Binom_BP_Model
+Binom_BP_Model.simulate({"seed": 123, "max_gen": 15, "n": 3, "p": 0.5, "max_infect": 500})
+```
+This should yield the following output: `[1, 2, 1, 1, 1, 2, 4, 8, 15, 24, 28, 38, 58, 86, 126]`
 
-Which will write `model_output.json` with the results of the run.  You
-can specify a different location with the `-o` command line argument.
+An equivalent approach is to read the model input from `defaults.json`. (The code here assumes working from the root of the repo.)
+
+```python
+import json
+from example_model import Binom_BP_Model
+model_inputs = json.load(open("./packages/example_model/defaults.json"))
+Binom_BP_Model.simulate(model_inputs)
+```
+To use the MRP functionality, create an environment that specifies the inputs and use the `.run()` method:
+```python
+from mrp import Environment
+from example_model import Binom_BP_Model
+model_inputs = {"max_gen": 15, "n": 3, "p": 0.5, "max_infect": 500}
+env = Environment({"input": model_inputs})
+Binom_BP_Model(env).run()
+```
+The above examples are very similar to those included in `scripts/direct_runner.py`, which can be run (from the root of the repo) with the following:
+```bash
+uv sync --all-packages
+uv run python scripts/direct_runner.py
+```
+Additionally, as described in the repo-level README, the model can be run as specified in the `example_model.mrp.toml`, which can be run as follows:
+```bash
+uv sync --all-packages
+uv run mrp run example_model.mrp.toml
+```


### PR DESCRIPTION
## Background
#11 made changes to the `example_model` package. The approach to running the model in the package-level README no longer works.

## What's changed
The purpose of this PR is to make changes to the README for the package. This helps demonstrate a number of ways to run the model and better relates to the MRP.

## Outstanding issues
This isn't specific to the README, but I think there's something I don't understand about how seeds are being handled in `mrp`. The results differ from run to run in the MRP-based approach in `direct_runner.py` and when using the `mrp.toml`. I think the issue is related to https://github.com/CDCgov/cfa-mrp/blob/87408c9724aa63f853dfbad83fbb66ddaa648b48/mrp-rs/src/lib.rs#L27, but I am not sure what to do / how to fix it in the context of this example model.