### PR TITLE
Added probability that seed is kept (non-breaking)

### DIFF
--- a/src/calibrationtools/perturbation_kernel.py
+++ b/src/calibrationtools/perturbation_kernel.py
@@ -148,6 +148,10 @@ class SeedKernel(SingleParameterPerturbationKernel):
     with a new integer value. The transition probability is always 1.0,
     indicating that the perturbation is deterministic given the seed sequence.
 
+    Args:
+        param (str): The name of the seed parameter to perturb.
+        prob_keep (float): The probability thatt he seed integer is kept. Must be between zero and one. Defaults to zero to preserve behavior that seed changes each perturbation.
+
     Methods:
         perturb(from_particle: Particle, seed_sequence: SeedSequence | None) -> Particle:
             Creates a new particle by copying the input particle and modifying
@@ -157,8 +161,8 @@ class SeedKernel(SingleParameterPerturbationKernel):
             Returns the transition probability between two particles, which is
             always 1.0 for this kernel.
 
-    Parameters:
-        params (list): A list containing the name of the "seed" parameter.
+    Raises:
+        ValueError: If the probability `prob_keep` is less than zero or greater than one.
 
     Notes:
         - The random integer is u32, generated in the range [0, 2^32 - 1].
@@ -166,19 +170,34 @@ class SeedKernel(SingleParameterPerturbationKernel):
           from the provided seed sequence.
     """
 
+    def __init__(self, param: str, prob_keep: float = 0.0) -> None:
+        super().__init__(param)
+        self.prob_keep = prob_keep
+        if self.prob_keep < 0.0 or self.prob_keep > 1.0:
+            raise ValueError(
+                "Probability of retaining value must be between 0 and 1."
+            )
+
     def perturb(
         self, from_particle: Particle, seed_sequence: SeedSequence | None
     ) -> Particle:
         to_particle = copy.deepcopy(from_particle)
-        to_particle[self.params[0]] = spawn_rng(seed_sequence).integers(
-            0, 2**32 - 1
-        )
+        rng = spawn_rng(seed_sequence)
+        if rng.uniform() < self.prob_keep:
+            to_particle[self.params[0]] = from_particle[self.params[0]]
+            # Sync RNG in case that we don't need a new value
+            rng.uniform()
+        else:
+            to_particle[self.params[0]] = rng.integers(0, 2**32 - 1)
         return to_particle
 
     def transition_probability(
         self, to_particle: Particle, from_particle: Particle
     ) -> float:
-        return 1.0
+        if to_particle[self.params[0]] == from_particle[self.params[0]]:
+            return self.prob_keep
+        else:
+            return 1.0 - self.prob_keep
 
 
 class UniformKernel(SingleParameterPerturbationKernel):

--- a/src/calibrationtools/perturbation_kernel.py
+++ b/src/calibrationtools/perturbation_kernel.py
@@ -150,7 +150,7 @@ class SeedKernel(SingleParameterPerturbationKernel):
 
     Args:
         param (str): The name of the seed parameter to perturb.
-        prob_keep (float): The probability thatt he seed integer is kept. Must be between zero and one. Defaults to zero to preserve behavior that seed changes each perturbation.
+        prob_keep (float): The probability that the seed integer is kept. Must be between zero and one. Defaults to zero to preserve behavior that seed changes each perturbation.
 
     Methods:
         perturb(from_particle: Particle, seed_sequence: SeedSequence | None) -> Particle:

--- a/tests/test_perturbation_kernel.py
+++ b/tests/test_perturbation_kernel.py
@@ -50,6 +50,40 @@ def test_seed_kernel_perturb(seed_sequence: SeedSequence) -> None:
     assert perturbed_particle_1["other"] == "value"
 
 
+def test_seed_kernel_perturb_keep(seed_sequence: SeedSequence) -> None:
+    kernel = SeedKernel("seed", prob_keep=1.0)
+
+    original_ss = copy.deepcopy(seed_sequence)
+    from_particle = Particle({"seed": 123, "other": "value"})
+
+    perturbed_particle_1 = kernel.perturb(from_particle, seed_sequence)
+    perturbed_particle_2 = kernel.perturb(from_particle, seed_sequence)
+    perturbed_particle_3 = kernel.perturb(from_particle, seed_sequence)
+    perturbed_particle_4 = kernel.perturb(from_particle, original_ss)
+
+    # Seeds should be the same between calls
+    assert perturbed_particle_1["seed"] == perturbed_particle_2["seed"]
+    assert perturbed_particle_2["seed"] == perturbed_particle_3["seed"]
+    # But same with same seed sequence
+    assert perturbed_particle_1["seed"] == perturbed_particle_4["seed"]
+    # Other values should be preserved
+    assert perturbed_particle_1["other"] == "value"
+
+
+def test_seed_kernel_perturb_half_keep(seed_sequence: SeedSequence) -> None:
+    kernel = SeedKernel("seed", prob_keep=0.5)
+
+    from_particle = Particle({"seed": 123, "other": "value"})
+
+    kept_count = 0
+    for _ in range(1000):
+        perturbed_particle = kernel.perturb(from_particle, seed_sequence)
+        if perturbed_particle["seed"] == from_particle["seed"]:
+            kept_count += 1
+    assert kept_count > 400
+    assert kept_count < 600
+
+
 def test_uniform_kernel_perturb(seed_sequence: SeedSequence) -> None:
     kernel = UniformKernel("param", width=5)
     from_particle = Particle({"param": 5, "other": "value"})


### PR DESCRIPTION
Update the `SeedKernel` class in `perturbation_kernel.py` with a configurable probability to retain the original seed value during perturbation, making the kernel's behavior more flexible for highly stochastic model parameterization. It also updates the transition probability calculation accordingly and adds comprehensive tests to verify the new functionality. Setting `prob_keep=0.0`, the default, recovers the previous implementation.

## Changes

* Added a `prob_keep` parameter to the `SeedKernel` constructor, allowing users to specify the probability that the seed integer is retained during perturbation. The constructor now validates that `prob_keep` is between 0 and 1, raising a `ValueError` otherwise. 
* Modified the `perturb` method to probabilistically decide whether to keep the original seed or generate a new one based on `prob_keep`, and updated the transition probability calculation to reflect this behavior.

## Behavior
### No seed re-use
Prior to the update, and when setting `prob_keep=0.0`, a branching process calibration with highly stochastic initial conditions looked like

<img width="813" height="198" alt="image" src="https://github.com/user-attachments/assets/0173d632-a25f-427f-8cdd-63cd62bb785a" />

### Seed re-use
For `prob_keep=0.1` , acceptance rates increased modestly in early steps, followed by reasonable gains in acceptance rate at later steps and greatly reduced simulation counts ($237,986 \to 87,458$). 

<img width="684" height="187" alt="image" src="https://github.com/user-attachments/assets/86ac9acb-3682-406e-97fe-14676c0268e6" />

After step 5 in this example, there were 273 unique seed values across the 500 particles, with ~200 singletons and most seeds being observed less than 5 times.
<img width="586" height="425" alt="image" src="https://github.com/user-attachments/assets/d0ae7644-2600-4b5b-8d0e-e677045d6287" />