### PR TITLE
Feat: Bounded beta prior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "cfa-mrp>=0.0.4",
     "jsonschema>=4.26.0",
     "numpy>=2.3.4",
+    "polars>=1.40.1",
     "pyarrow>=23.0.0",
     "rich>=14.3.3",
     "scipy>=1.16.3",

--- a/src/calibrationtools/__init__.py
+++ b/src/calibrationtools/__init__.py
@@ -13,6 +13,7 @@ from .particle_reader import (
     flatten_dict,
     unflatten_parameter_name,
 )
+from .particle_runner import ParticleRunner
 from .particle_updater import _ParticleUpdater
 from .perturbation_kernel import (
     IndependentKernels,
@@ -50,6 +51,7 @@ __all__ = [
     "ParticlePopulation",
     "ParticlePopulationMetrics",
     "ParticleReader",
+    "ParticleRunner",
     "_ParticleUpdater",
     "PriorDistribution",
     "UniformPrior",

--- a/src/calibrationtools/assets/schema.json
+++ b/src/calibrationtools/assets/schema.json
@@ -141,7 +141,9 @@
                         "type": "object",
                         "properties": {
                             "alpha": {"type": "number", "exclusiveMinimum": 0},
-                            "beta": {"type": "number", "exclusiveMinimum": 0}
+                            "beta": {"type": "number", "exclusiveMinimum": 0},
+                            "min": {"type": "number"},
+                            "max": {"type": "number"}
                         },
                         "required": ["alpha", "beta"],
                         "additionalProperties": false

--- a/src/calibrationtools/load_priors.py
+++ b/src/calibrationtools/load_priors.py
@@ -96,6 +96,8 @@ def independent_priors_from_dict(
                         k,
                         alpha=parameters["alpha"],
                         beta=parameters["beta"],
+                        min=parameters.get("min", 0.0),
+                        max=parameters.get("max", 1.0),
                     )
                 )
             case _:

--- a/src/calibrationtools/particle_population.py
+++ b/src/calibrationtools/particle_population.py
@@ -1,4 +1,6 @@
-from typing import Any, Sequence
+from typing import Any, Self, Sequence
+
+import polars as pl
 
 from .particle import Particle
 
@@ -116,6 +118,44 @@ class ParticlePopulation:
             normalization_factor = 1.0 / self.total_weight
             for i in range(self.size):
                 self.weights[i] *= normalization_factor
+
+    def join(self, other: Self | Sequence[Particle] | pl.DataFrame) -> Self:
+        """
+        Method to cross join the current ParticlePopulation with another ParticlePopulation, a sequence of Particles, or a Polars DataFrame.
+        Args:
+            other (Self | Sequence[Particle] | pl.DataFrame): The other population, sequence of particles, or DataFrame to join with.
+        Returns:
+            Self: A new ParticlePopulation resulting from the cross join.
+        Raises:
+            TypeError: If the 'other' argument is not a ParticlePopulation, Sequence[Particle], or pl.DataFrame.
+        """
+        if isinstance(other, self.__class__):
+            other_particles = other.particles
+            other_weights = other.weights
+        elif isinstance(other, Sequence) and all(
+            isinstance(p, Particle) for p in other
+        ):
+            other_particles = list(other)
+            other_weights = [1.0] * len(other_particles)
+        elif isinstance(other, pl.DataFrame):
+            other_particles = [
+                Particle(row) for row in other.iter_rows(named=True)
+            ]
+            other_weights = [1.0] * len(other_particles)
+        else:
+            raise TypeError(
+                "Unsupported type for joining: must be ParticlePopulation, Sequence[Particle], or pl.DataFrame"
+            )
+
+        new_population = self.__class__()
+        for p1, w1 in zip(self.particles, self.weights):
+            for p2, w2 in zip(other_particles, other_weights):
+                new_particle = Particle({**p1.data, **p2.data})
+                new_weight = w1 * w2
+                new_population.add_particle(new_particle, new_weight)
+
+        new_population.normalize_weights()
+        return new_population
 
     def __repr__(self):
         return f"ParticlePopulation(size={self.size}, ESS={self.ess})"

--- a/src/calibrationtools/particle_runner.py
+++ b/src/calibrationtools/particle_runner.py
@@ -4,9 +4,10 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, Concatenate, Literal
 
+from .async_runner import run_coroutine_from_sync
 from .particle import Particle
 from .sampler_reporting import SamplerReporter
-from .async_runner import run_coroutine_from_sync
+
 
 async def _run_particles_helper(
     particles: list[Particle],
@@ -22,8 +23,8 @@ async def _run_particles_helper(
         particles (list[Particle]): List of particles to run the worker function on
         executor (ThreadPoolExecutor): Executor to run the worker function on
         worker (Callable[[list[Particle]], Any]): Worker function to run on each particle
-        chunksize (int, optional): Number of particles to run in each chunk. Defaults to 1.
-        reporter (SamplerReporter, optional): Reporter to use for progress reporting. Defaults to None, in which case a new SamplerReporter will be created.
+        chunksize (int): Number of particles to run in each chunk. Defaults to 1.
+        reporter (SamplerReporter | None): Optional reporter to use for progress reporting. Defaults to None, in which case a new SamplerReporter will be created.
 
     """
     if reporter is None:
@@ -70,6 +71,7 @@ class ParticleRunner:
         execution (Literal["parallel", "serial"], optional): Whether to run particles in parallel using threads or serially. Defaults to "parallel".
         max_workers (int | None, optional): Maximum number of worker threads to use for parallel execution. If None or 0, it will be set to the number of CPU cores available. Defaults to None.
     """
+
     def __init__(
         self,
         model: Any,
@@ -89,7 +91,7 @@ class ParticleRunner:
             max_workers (int | None): The maximum number of workers to use for parallel execution. If None or 0, it will be set to the number of CPU cores available.
         """
         if not max_workers:
-            self.max_workers = os.process_cpu_count() or os.cpu_count() or 1
+            self.max_workers = os.cpu_count() or 1
         else:
             self.max_workers = max_workers
 
@@ -112,13 +114,15 @@ class ParticleRunner:
         threaded batch-processing paths.
 
         Args:
-            proposed_particles (list[Particle]): Proposed particles to score.
-            particle_kwargs (dict[str, Any]): Additional keyword arguments
-                forwarded into particle evaluation.
+            particles (list[Particle]): Proposed particles to score.
+            **kwargs: Additional keyword arguments forwarded into particle evaluation.
+        Returns:
+            list[Any]: List of model outputs corresponding to the proposed particles.
         """
 
         return [
-            self.run_particle(particle=particle, **kwargs) for particle in particles
+            self.run_particle(particle=particle, **kwargs)
+            for particle in particles
         ]
 
     def run(self, particles: list[Particle]):
@@ -151,4 +155,6 @@ class ParticleRunner:
                     reporter.advance(handle)
 
                 end = time.time()
-                reporter.print_run_summary(end - start, process_name="Simulations")
+                reporter.print_run_summary(
+                    end - start, process_name="Simulations"
+                )

--- a/src/calibrationtools/particle_runner.py
+++ b/src/calibrationtools/particle_runner.py
@@ -1,0 +1,154 @@
+import asyncio
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Concatenate, Literal
+
+from .particle import Particle
+from .sampler_reporting import SamplerReporter
+from .async_runner import run_coroutine_from_sync
+
+async def _run_particles_helper(
+    particles: list[Particle],
+    executor: ThreadPoolExecutor,
+    worker: Callable[[list[Particle]], Any],
+    chunksize: int = 1,
+    reporter: SamplerReporter | None = None,
+):
+    """
+    Async function to call a worker function on each member of a list of Particles in parallel
+
+    Args:
+        particles (list[Particle]): List of particles to run the worker function on
+        executor (ThreadPoolExecutor): Executor to run the worker function on
+        worker (Callable[[list[Particle]], Any]): Worker function to run on each particle
+        chunksize (int, optional): Number of particles to run in each chunk. Defaults to 1.
+        reporter (SamplerReporter, optional): Reporter to use for progress reporting. Defaults to None, in which case a new SamplerReporter will be created.
+
+    """
+    if reporter is None:
+        reporter = SamplerReporter(verbose=True)
+
+    with reporter.create_task_progress() as progress:
+        assert executor is not None
+        start = time.time()
+        handle = reporter.start_task(
+            description="Simulating results from model... ",
+            progress=progress,
+            total=len(particles),
+        )
+        loop = asyncio.get_running_loop()
+        particle_chunks = [
+            particles[index : index + chunksize]
+            for index in range(0, len(particles), chunksize)
+        ]
+        tasks = []
+        for chunk in particle_chunks:
+            task = loop.run_in_executor(executor, worker, chunk)
+            tasks.append((task, chunk))
+
+        try:
+            for task, chunk in tasks:
+                _chunk_results = await task
+                reporter.advance(handle)
+        finally:
+            for task, _ in tasks:
+                task.cancel()
+
+        end = time.time()
+        reporter.print_run_summary(end - start, process_name="Simulations")
+
+
+class ParticleRunner:
+    """
+    ParticleRunner is a utility class for running Particle objects through a user-supplied model. It supports both parallel and serial execution modes, and can be configured with a custom function to convert Particle instances into the parameter dictionaries expected by the model.
+    This class is designed to keep the details of parallel execution and model interfacing
+    contained in one place, so that the ABCSampler can focus on the logic of the sampling algorithm itself.
+    Args:
+        model (Any): User-supplied model object that has a .simulate(params: dict) method for running simulations.
+        particles_to_params (Callable[Concatenate[Particle, ...], dict]): Function that converts a Particle instance into a parameter dictionary for the model. It should accept the particle as its first argument and return a dict of parameters to be passed to the model's simulate method.
+        execution (Literal["parallel", "serial"], optional): Whether to run particles in parallel using threads or serially. Defaults to "parallel".
+        max_workers (int | None, optional): Maximum number of worker threads to use for parallel execution. If None or 0, it will be set to the number of CPU cores available. Defaults to None.
+    """
+    def __init__(
+        self,
+        model: Any,
+        particles_to_params: Callable[Concatenate[Particle, ...], dict],
+        execution: Literal["parallel", "serial"] = "parallel",
+        max_workers: int | None = None,
+    ):
+        self.model = model
+        self.parallel = execution == "parallel"
+        self._set_worker_count(max_workers)
+        self.particles_to_params = particles_to_params
+
+    def _set_worker_count(self, max_workers: int | None = None):
+        """
+        Set the number of workers to use for parallel execution. If max_workers is None or 0, it will be set to the number of CPU cores available.
+        Args:
+            max_workers (int | None): The maximum number of workers to use for parallel execution. If None or 0, it will be set to the number of CPU cores available.
+        """
+        if not max_workers:
+            self.max_workers = os.process_cpu_count() or os.cpu_count() or 1
+        else:
+            self.max_workers = max_workers
+
+    def run_particle(self, particle: Particle, **kwargs):
+        """
+        Run a single particle through the model.
+        Args:
+            particle (Particle): Particle to run through the model
+            **kwargs: Additional keyword arguments forwarded into particle evaluation
+        """
+        particle_params = self.particles_to_params(particle=particle, **kwargs)
+        self.model.simulate(particle_params)
+
+    def _evaluate_particle_chunk(
+        self, particles: list[Particle], **kwargs
+    ) -> list[Any]:
+        """Evaluate a chunk of proposed particles serially.
+
+        This helper keeps chunk evaluation reusable between the serial and
+        threaded batch-processing paths.
+
+        Args:
+            proposed_particles (list[Particle]): Proposed particles to score.
+            particle_kwargs (dict[str, Any]): Additional keyword arguments
+                forwarded into particle evaluation.
+        """
+
+        return [
+            self.run_particle(particle=particle, **kwargs) for particle in particles
+        ]
+
+    def run(self, particles: list[Particle]):
+        """
+        Call the particle evaluation for each member of a list of Particles
+        Args:
+            particles (list[Particle]): List of particles to run the worker function on
+        """
+        if self.parallel:
+            run_coroutine_from_sync(
+                lambda: _run_particles_helper(
+                    executor=ThreadPoolExecutor(max_workers=self.max_workers),
+                    worker=self._evaluate_particle_chunk,
+                    chunksize=1,
+                    reporter=SamplerReporter(verbose=True),
+                    particles=particles,
+                )
+            )
+        else:
+            reporter = SamplerReporter(verbose=True)
+            with reporter.create_task_progress() as progress:
+                start = time.time()
+                handle = reporter.start_task(
+                    description="Simulating results from model... ",
+                    progress=progress,
+                    total=len(particles),
+                )
+                for particle in particles:
+                    self.run_particle(particle=particle)
+                    reporter.advance(handle)
+
+                end = time.time()
+                reporter.print_run_summary(end - start, process_name="Simulations")

--- a/src/calibrationtools/prior_distribution.py
+++ b/src/calibrationtools/prior_distribution.py
@@ -320,36 +320,65 @@ class BetaPrior(SingleParameterPriorDistribution):
     Represents a beta prior distribution for a single parameter.
 
     The beta distribution is defined by two shape parameters (α and β), both of which must be positive.
+    By default it has support on [0, 1]; supplying `min` and `max` shifts and scales it onto [min, max],
+    which lets a beta express a bounded prior for a parameter that is not a probability.
     This class provides methods to sample from the distribution and calculate the probability density for a given particle.
 
     Args:
         param (str): The name of the parameter this prior is associated with.
         alpha (float): The first shape parameter (α) of the beta distribution. Must be positive.
         beta (float): The second shape parameter (β) of the beta distribution. Must be positive.
+        min (float): The lower bound of the support. Defaults to 0.0.
+        max (float): The upper bound of the support. Must exceed `min`. Defaults to 1.0.
     Raises:
-        ValueError: If `alpha` or `beta` is not positive.
+        ValueError: If `alpha` or `beta` is not positive, or if `min` is not less than `max`.
     """
 
-    def __init__(self, param: str, alpha: float, beta: float) -> None:
+    def __init__(
+        self,
+        param: str,
+        alpha: float,
+        beta: float,
+        min: float = 0.0,
+        max: float = 1.0,
+    ) -> None:
         super().__init__(param)
         self.alpha = alpha
         self.beta = beta
+        self.min = min
+        self.max = max
         if self.alpha <= 0:
             raise ValueError("Alpha must be positive for BetaPrior.")
         if self.beta <= 0:
             raise ValueError("Beta must be positive for BetaPrior.")
+        if self.min >= self.max:
+            raise ValueError("Min must be less than max for BetaPrior.")
+
+    @property
+    def _width(self) -> float:
+        return self.max - self.min
 
     def sample(
         self, n: int, seed: SeedSequence | None
     ) -> Sequence[dict[str, Any]]:
         rng = spawn_rng(seed)
         return [
-            {self.param: rng.beta(self.alpha, self.beta)} for _ in range(n)
+            {
+                self.param: self.min
+                + self._width * rng.beta(self.alpha, self.beta)
+            }
+            for _ in range(n)
         ]
 
     def probability_density(self, particle: Particle) -> float:
         return float(
-            beta.pdf(particle[self.params[0]], a=self.alpha, b=self.beta)
+            beta.pdf(
+                particle[self.params[0]],
+                a=self.alpha,
+                b=self.beta,
+                loc=self.min,
+                scale=self._width,
+            )
         )
 
 

--- a/tests/test_load_priors.py
+++ b/tests/test_load_priors.py
@@ -234,6 +234,28 @@ def test_invalid_schema_beta_parameters():
         validate_schema(bad_schema)
 
 
+def test_schema_allows_bounded_beta():
+    schema = {
+        "priors": {
+            "param7": {
+                "distribution": "beta",
+                "parameters": {
+                    "alpha": 2,
+                    "beta": 5,
+                    "min": 5.7,
+                    "max": 11.3,
+                },
+            }
+        }
+    }
+    validate_schema(schema)
+    priors = independent_priors_from_dict(schema, incl_seed_parameter=False)
+    (prior,) = priors.priors
+    assert isinstance(prior, BetaPrior)
+    assert prior.min == 5.7
+    assert prior.max == 11.3
+
+
 def test_invalid_schema_missing_parameters():
     bad_schema = {
         "priors": {

--- a/tests/test_particle_population.py
+++ b/tests/test_particle_population.py
@@ -1,3 +1,4 @@
+import polars as pl
 import pytest
 
 from calibrationtools import Particle, ParticlePopulation
@@ -86,3 +87,84 @@ def test_empty_particle_population_normalize_weights_noop() -> None:
 
     assert population.size == 0
     assert population.total_weight == 0.0
+
+
+def test_particle_join(population, state, state2) -> None:
+    new_particles = [Particle({"new_x": 5.0}), Particle({"new_x": 6.0})]
+    new_population = population.join(new_particles)
+
+    # Assert no changes to base population
+    assert population.size == 2
+    assert population.particles[0] == state
+    assert population.particles[1] == state2
+
+    assert new_population.size == 4
+    assert new_population.particles[0] == {"x": 1.0, "y": 2.0, "new_x": 5.0}
+    assert new_population.particles[1] == {"x": 1.0, "y": 2.0, "new_x": 6.0}
+    assert new_population.particles[2] == {"x": 3.0, "y": 4.0, "new_x": 5.0}
+    assert new_population.particles[3] == {"x": 3.0, "y": 4.0, "new_x": 6.0}
+
+
+def test_particle_join_with_weights(population, state, state2) -> None:
+    new_particle_population = ParticlePopulation(
+        states=[{"new_x": 5.0}, {"new_x": 6.0}],
+        weights=[0.4, 0.6],
+    )
+    new_population = population.join(new_particle_population)
+
+    # Assert no changes to base population
+    assert population.size == 2
+    assert population.particles[0] == state
+    assert population.particles[1] == state2
+
+    assert new_population.size == 4
+    assert new_population.particles[0] == {"x": 1.0, "y": 2.0, "new_x": 5.0}
+    assert new_population.particles[1] == {"x": 1.0, "y": 2.0, "new_x": 6.0}
+    assert new_population.particles[2] == {"x": 3.0, "y": 4.0, "new_x": 5.0}
+    assert new_population.particles[3] == {"x": 3.0, "y": 4.0, "new_x": 6.0}
+    assert new_population.weights[0] == pytest.approx(0.4 * 0.3)
+    assert new_population.weights[1] == pytest.approx(0.6 * 0.3)
+    assert new_population.weights[2] == pytest.approx(0.4 * 0.7)
+    assert new_population.weights[3] == pytest.approx(0.6 * 0.7)
+
+
+def test_particle_join_overwrites_original(population, state, state2) -> None:
+    new_particles = [Particle({"y": 5.0}), Particle({"y": 6.0})]
+    joined_population = population.join(new_particles)
+
+    # Assert no changes to base population
+    assert population.size == 2
+    assert population.particles[0] == state
+    assert population.particles[1] == state2
+
+    # Assert correct joining of particles
+    assert joined_population.size == 4
+    assert joined_population.particles[0] == {"x": 1.0, "y": 5.0}
+    assert joined_population.particles[1] == {"x": 1.0, "y": 6.0}
+    assert joined_population.particles[2] == {"x": 3.0, "y": 5.0}
+    assert joined_population.particles[3] == {"x": 3.0, "y": 6.0}
+
+
+def test_particle_join_type_behavior(population) -> None:
+    new_data = [{"z": 5.0}, {"z": 6.0}]
+    new_particles = [Particle(p) for p in new_data]
+    dataframe = pl.DataFrame({"z": [v["z"] for v in new_data]})
+    new_population = ParticlePopulation(states=new_data)
+
+    sequence_join = population.join(new_particles)
+    dataframe_join = population.join(dataframe)
+    population_join = population.join(new_population)
+
+    assert isinstance(sequence_join, ParticlePopulation)
+    assert isinstance(dataframe_join, ParticlePopulation)
+    assert isinstance(population_join, ParticlePopulation)
+    assert (
+        population_join.particles
+        == sequence_join.particles
+        == dataframe_join.particles
+    )
+    assert (
+        population_join.weights
+        == sequence_join.weights
+        == dataframe_join.weights
+    )

--- a/tests/test_particle_runner.py
+++ b/tests/test_particle_runner.py
@@ -1,0 +1,309 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+from calibrationtools import Particle
+from calibrationtools.particle_runner import ParticleRunner, _run_particles_helper
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def particle() -> Particle:
+    return Particle({"x": 42})
+
+
+@pytest.fixture
+def multi_param_particle() -> Particle:
+    return Particle({"rate": 0.5, "seed": 99})
+
+
+def identity_params(particle: Particle) -> dict:
+    """particles_to_params that returns the particle's own state."""
+    return dict(particle.items())
+
+
+# ---------------------------------------------------------------------------
+# ParticleRunner.__init__ / _set_worker_count
+# ---------------------------------------------------------------------------
+
+
+class TestParticleRunnerInit:
+    def test_parallel_is_default(self):
+        model = MagicMock()
+        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+        assert runner.parallel is True
+
+    def test_serial_execution(self):
+        model = MagicMock()
+        runner = ParticleRunner(
+            model=model,
+            particles_to_params=identity_params,
+            execution="serial",
+        )
+        assert runner.parallel is False
+
+    def test_explicit_max_workers(self):
+        model = MagicMock()
+        runner = ParticleRunner(
+            model=model, particles_to_params=identity_params, max_workers=4
+        )
+        assert runner.max_workers == 4
+
+    def test_zero_max_workers_uses_cpu_count(self):
+        model = MagicMock()
+        with patch(
+            "calibrationtools.particle_runner.os.process_cpu_count", return_value=8
+        ):
+            runner = ParticleRunner(
+                model=model, particles_to_params=identity_params, max_workers=0
+            )
+        assert runner.max_workers == 8
+
+    def test_none_max_workers_uses_cpu_count(self):
+        model = MagicMock()
+        with patch(
+            "calibrationtools.particle_runner.os.process_cpu_count", return_value=4
+        ):
+            runner = ParticleRunner(
+                model=model, particles_to_params=identity_params, max_workers=None
+            )
+        assert runner.max_workers == 4
+
+    def test_fallback_to_os_cpu_count(self):
+        model = MagicMock()
+        with (
+            patch(
+                "calibrationtools.particle_runner.os.process_cpu_count",
+                return_value=None,
+            ),
+            patch("calibrationtools.particle_runner.os.cpu_count", return_value=2),
+        ):
+            runner = ParticleRunner(
+                model=model, particles_to_params=identity_params, max_workers=None
+            )
+        assert runner.max_workers == 2
+
+    def test_fallback_to_one_when_cpu_count_unavailable(self):
+        model = MagicMock()
+        with (
+            patch(
+                "calibrationtools.particle_runner.os.process_cpu_count",
+                return_value=None,
+            ),
+            patch("calibrationtools.particle_runner.os.cpu_count", return_value=None),
+        ):
+            runner = ParticleRunner(
+                model=model, particles_to_params=identity_params, max_workers=None
+            )
+        assert runner.max_workers == 1
+
+
+# ---------------------------------------------------------------------------
+# ParticleRunner.run_particle
+# ---------------------------------------------------------------------------
+
+
+class TestRunParticle:
+    def test_calls_particles_to_params_and_simulate(self, particle):
+        model = MagicMock()
+        p2p = MagicMock(return_value={"x": 42})
+        runner = ParticleRunner(model=model, particles_to_params=p2p)
+        particle = particle
+
+        runner.run_particle(particle)
+
+        p2p.assert_called_once_with(particle=particle)
+        model.simulate.assert_called_once_with({"x": 42})
+
+    def test_kwargs_forwarded_to_particles_to_params(self, particle):
+        model = MagicMock()
+        p2p = MagicMock(return_value={})
+        runner = ParticleRunner(model=model, particles_to_params=p2p)
+        particle = particle
+
+        runner.run_particle(particle, extra="kwarg")
+
+        p2p.assert_called_once_with(particle=particle, extra="kwarg")
+
+    def test_simulate_receives_correct_params(self, multi_param_particle):
+        model = MagicMock()
+        params = {"rate": 0.5, "seed": 99}
+        runner = ParticleRunner(
+            model=model, particles_to_params=lambda particle: params
+        )
+        runner.run_particle(multi_param_particle)
+        model.simulate.assert_called_once_with(params)
+
+
+# ---------------------------------------------------------------------------
+# ParticleRunner._evaluate_particle_chunk
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateParticleChunk:
+    def test_runs_all_particles_in_chunk(self, particle):
+        model = MagicMock()
+        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+        particles = [particle for i in range(3)]
+
+        runner._evaluate_particle_chunk(particles)
+
+        assert model.simulate.call_count == 3
+
+    def test_empty_chunk_makes_no_calls(self):
+        model = MagicMock()
+        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+
+        runner._evaluate_particle_chunk([])
+
+        model.simulate.assert_not_called()
+
+    def test_returns_list_of_results(self, particle):
+        model = MagicMock()
+        model.simulate.return_value = "result"
+        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+        particles = [particle for i in range(2)]
+
+        result = runner._evaluate_particle_chunk(particles)
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# ParticleRunner.run – serial path
+# ---------------------------------------------------------------------------
+
+
+class TestRunSerial:
+    def test_all_particles_simulated(self, particle):
+        model = MagicMock()
+        runner = ParticleRunner(
+            model=model,
+            particles_to_params=identity_params,
+            execution="serial",
+        )
+        particles = [particle for i in range(5)]
+
+        runner.run(particles)
+
+        assert model.simulate.call_count == 5
+
+    def test_empty_particle_list(self):
+        model = MagicMock()
+        runner = ParticleRunner(
+            model=model,
+            particles_to_params=identity_params,
+            execution="serial",
+        )
+        runner.run([])  # should not raise
+        model.simulate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# ParticleRunner.run – parallel path
+# ---------------------------------------------------------------------------
+
+
+class TestRunParallel:
+    def test_all_particles_simulated(self, particle):
+        model = MagicMock()
+        runner = ParticleRunner(
+            model=model,
+            particles_to_params=identity_params,
+            execution="parallel",
+            max_workers=2,
+        )
+        particles = [particle for i in range(4)]
+
+        runner.run(particles)
+
+        assert model.simulate.call_count == 4
+
+    def test_empty_particle_list(self):
+        model = MagicMock()
+        runner = ParticleRunner(
+            model=model,
+            particles_to_params=identity_params,
+            execution="parallel",
+        )
+        runner.run([])  # should not raise
+        model.simulate.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_particles (async helper)
+# ---------------------------------------------------------------------------
+
+
+class TestRunParticlesAsync:
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_worker_called_once_per_particle_with_chunksize_1(self, particle):
+        worker = MagicMock(return_value=None)
+        particles = [particle for i in range(3)]
+        executor = ThreadPoolExecutor(max_workers=2)
+
+        self._run(
+            _run_particles_helper(
+                particles=particles,
+                executor=executor,
+                worker=worker,
+                chunksize=1,
+            )
+        )
+
+        assert worker.call_count == 3
+
+    def test_worker_called_once_per_chunk_with_larger_chunksize(self, particle):
+        worker = MagicMock(return_value=None)
+        particles = [particle for i in range(6)]
+        executor = ThreadPoolExecutor(max_workers=2)
+
+        self._run(
+            _run_particles_helper(
+                particles=particles,
+                executor=executor,
+                worker=worker,
+                chunksize=3,
+            )
+        )
+
+        assert worker.call_count == 2
+
+    def test_empty_particle_list(self):
+        worker = MagicMock(return_value=None)
+        executor = ThreadPoolExecutor(max_workers=1)
+
+        self._run(
+            _run_particles_helper(
+                particles=[],
+                executor=executor,
+                worker=worker,
+                chunksize=1,
+            )
+        )
+
+        worker.assert_not_called()
+
+    def test_default_reporter_created_when_none_provided(self, particle):
+        worker = MagicMock(return_value=None)
+        particles = [particle]
+        executor = ThreadPoolExecutor(max_workers=1)
+
+        # Should not raise even with reporter=None
+        self._run(
+            _run_particles_helper(
+                particles=particles,
+                executor=executor,
+                worker=worker,
+                reporter=None,
+            )
+        )
+
+        worker.assert_called_once()

--- a/tests/test_particle_runner.py
+++ b/tests/test_particle_runner.py
@@ -3,8 +3,12 @@ from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from calibrationtools import Particle
-from calibrationtools.particle_runner import ParticleRunner, _run_particles_helper
+from calibrationtools.particle_runner import (
+    ParticleRunner,
+    _run_particles_helper,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,7 +38,9 @@ def identity_params(particle: Particle) -> dict:
 class TestParticleRunnerInit:
     def test_parallel_is_default(self):
         model = MagicMock()
-        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+        runner = ParticleRunner(
+            model=model, particles_to_params=identity_params
+        )
         assert runner.parallel is True
 
     def test_serial_execution(self):
@@ -56,7 +62,8 @@ class TestParticleRunnerInit:
     def test_zero_max_workers_uses_cpu_count(self):
         model = MagicMock()
         with patch(
-            "calibrationtools.particle_runner.os.process_cpu_count", return_value=8
+            "calibrationtools.particle_runner.os.cpu_count",
+            return_value=8,
         ):
             runner = ParticleRunner(
                 model=model, particles_to_params=identity_params, max_workers=0
@@ -66,38 +73,38 @@ class TestParticleRunnerInit:
     def test_none_max_workers_uses_cpu_count(self):
         model = MagicMock()
         with patch(
-            "calibrationtools.particle_runner.os.process_cpu_count", return_value=4
+            "calibrationtools.particle_runner.os.cpu_count",
+            return_value=4,
         ):
             runner = ParticleRunner(
-                model=model, particles_to_params=identity_params, max_workers=None
+                model=model,
+                particles_to_params=identity_params,
+                max_workers=None,
             )
         assert runner.max_workers == 4
 
     def test_fallback_to_os_cpu_count(self):
         model = MagicMock()
-        with (
-            patch(
-                "calibrationtools.particle_runner.os.process_cpu_count",
-                return_value=None,
-            ),
-            patch("calibrationtools.particle_runner.os.cpu_count", return_value=2),
+        with patch(
+            "calibrationtools.particle_runner.os.cpu_count", return_value=2
         ):
             runner = ParticleRunner(
-                model=model, particles_to_params=identity_params, max_workers=None
+                model=model,
+                particles_to_params=identity_params,
+                max_workers=None,
             )
         assert runner.max_workers == 2
 
     def test_fallback_to_one_when_cpu_count_unavailable(self):
         model = MagicMock()
-        with (
-            patch(
-                "calibrationtools.particle_runner.os.process_cpu_count",
-                return_value=None,
-            ),
-            patch("calibrationtools.particle_runner.os.cpu_count", return_value=None),
+        with patch(
+            "calibrationtools.particle_runner.os.cpu_count",
+            return_value=None,
         ):
             runner = ParticleRunner(
-                model=model, particles_to_params=identity_params, max_workers=None
+                model=model,
+                particles_to_params=identity_params,
+                max_workers=None,
             )
         assert runner.max_workers == 1
 
@@ -147,7 +154,9 @@ class TestRunParticle:
 class TestEvaluateParticleChunk:
     def test_runs_all_particles_in_chunk(self, particle):
         model = MagicMock()
-        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+        runner = ParticleRunner(
+            model=model, particles_to_params=identity_params
+        )
         particles = [particle for i in range(3)]
 
         runner._evaluate_particle_chunk(particles)
@@ -156,7 +165,9 @@ class TestEvaluateParticleChunk:
 
     def test_empty_chunk_makes_no_calls(self):
         model = MagicMock()
-        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+        runner = ParticleRunner(
+            model=model, particles_to_params=identity_params
+        )
 
         runner._evaluate_particle_chunk([])
 
@@ -165,7 +176,9 @@ class TestEvaluateParticleChunk:
     def test_returns_list_of_results(self, particle):
         model = MagicMock()
         model.simulate.return_value = "result"
-        runner = ParticleRunner(model=model, particles_to_params=identity_params)
+        runner = ParticleRunner(
+            model=model, particles_to_params=identity_params
+        )
         particles = [particle for i in range(2)]
 
         result = runner._evaluate_particle_chunk(particles)
@@ -260,7 +273,9 @@ class TestRunParticlesAsync:
 
         assert worker.call_count == 3
 
-    def test_worker_called_once_per_chunk_with_larger_chunksize(self, particle):
+    def test_worker_called_once_per_chunk_with_larger_chunksize(
+        self, particle
+    ):
         worker = MagicMock(return_value=None)
         particles = [particle for i in range(6)]
         executor = ThreadPoolExecutor(max_workers=2)

--- a/tests/test_prior_distribution.py
+++ b/tests/test_prior_distribution.py
@@ -1,5 +1,6 @@
 from math import exp
 
+import pytest
 from numpy.random import SeedSequence
 from scipy.stats import beta, expon, gamma, lognorm, norm
 
@@ -148,6 +149,33 @@ def test_beta_prior_probability() -> None:
     expected = beta.pdf(0.5, a=alpha, b=beta_param)
 
     assert prior.probability_density(Particle({"x": 0.5})) == expected
+
+
+def test_beta_prior_bounded_sampling(seed_sequence: SeedSequence) -> None:
+    prior = BetaPrior(param="x", alpha=2.0, beta=5.0, min=5.7, max=11.3)
+    samples = [s["x"] for s in prior.sample(50, seed_sequence)]
+
+    assert all(5.7 <= v <= 11.3 for v in samples)
+
+
+def test_beta_prior_bounded_probability() -> None:
+    alpha = 2.0
+    beta_param = 5.0
+    prior = BetaPrior(
+        param="x", alpha=alpha, beta=beta_param, min=5.7, max=11.3
+    )
+    expected = beta.pdf(8.0, a=alpha, b=beta_param, loc=5.7, scale=11.3 - 5.7)
+
+    assert prior.probability_density(Particle({"x": 8.0})) == pytest.approx(
+        expected
+    )
+    assert prior.probability_density(Particle({"x": 5.6})) == 0.0
+    assert prior.probability_density(Particle({"x": 11.4})) == 0.0
+
+
+def test_beta_prior_rejects_inverted_bounds() -> None:
+    with pytest.raises(ValueError, match="Min must be less than max"):
+        BetaPrior(param="x", alpha=2.0, beta=5.0, min=11.3, max=5.7)
 
 
 def test_independent_priors_sampling(

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ dependencies = [
     { name = "cfa-mrp" },
     { name = "jsonschema" },
     { name = "numpy" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "rich" },
     { name = "scipy" },
@@ -42,6 +43,7 @@ requires-dist = [
     { name = "cfa-mrp", specifier = ">=0.0.4" },
     { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "numpy", specifier = ">=2.3.4" },
+    { name = "polars", specifier = ">=1.40.1" },
     { name = "pyarrow", specifier = ">=23.0.0" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "scipy", specifier = ">=1.16.3" },
@@ -254,6 +256,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8c/bc9bc948058348ed43117cecc3007cd608f395915dae8a00974579a5dab1/polars-1.40.1.tar.gz", hash = "sha256:ab2694134b137596b5a59bfd7b4c54ebbc9b59f9403127f18e32d363777552e8", size = 733574, upload-time = "2026-04-22T19:15:55.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/91/74fc60d94488685a92ac9d49d7ec55f3e91fe9b77942a6235a5fa7f249c3/polars-1.40.1-py3-none-any.whl", hash = "sha256:c0f861219d1319cdea45c4ce4d30355a47176b8f98dcedf95ea8269f131b8abd", size = 828723, upload-time = "2026-04-22T19:14:25.452Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ba/26d40f039be9f552b5fd7365a621bdfc0f8e912ef77094ae4693491b0bae/polars_runtime_32-1.40.1.tar.gz", hash = "sha256:37f3065615d1bf90d03b5326222df4c5c1f8a5d33e50470aa588e3465e6eb814", size = 2935843, upload-time = "2026-04-22T19:15:57.26Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/46/22c8af5eed68ac2eeb556e0fa3ca8a7b798e984ceff4450888f3b5ac61fd/polars_runtime_32-1.40.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b748ef652270cc49e9e69f99a035e0eb4d5f856d42bcd6ac4d9d80a40142aa1e", size = 52098755, upload-time = "2026-04-22T19:14:28.555Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/48599a38009ca60ff82a6f38c8a621ce3c0286aa7397c7d79e741bd9060e/polars_runtime_32-1.40.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d249b3743e05986060cec0a7aaa542d020df6c6b876e556023a310efd581f9be", size = 46367542, upload-time = "2026-04-22T19:14:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e9/384bc069367a1a36ee31c13782c178dbd039b2b873b772d4a0fc23a2373d/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5987b30e7aa1059d069498496e8dda35afd592b0ac3d46ed87e3ff8df1ad652c", size = 50252104, upload-time = "2026-04-22T19:14:35.945Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ef/7d57ceb0651af74194e97ed6583e148d352f03d696090221b8059cdfc90b/polars_runtime_32-1.40.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d7f42a8b3f16fc66002cc0f6516f7dd7653396886ae0ed362ab95c0b3408b59", size = 56250788, upload-time = "2026-04-22T19:14:39.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0f/e4b3ffc748827a14a474ec9c42e45c066050e440fec57e914091d9adda75/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:e5f7becc237a7ec9d9a10878dc8e54b73bbf4e2d94a2991c37d7a0b38590d8f9", size = 50432590, upload-time = "2026-04-22T19:14:43.388Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/0b/b8d95fbed869fa4caabe9c400e4210374913b376e925e96fdcfa9be6416b/polars_runtime_32-1.40.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:992d14cf191dde043d36fbdbc98a65e43fbc7e9a5024cecd45f838ac4988c1ee", size = 54155564, upload-time = "2026-04-22T19:14:47.239Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d9/d091d8fb5cbed5e9536adfed955c4c89987a4cc3b8e73ae4532402b91c74/polars_runtime_32-1.40.1-cp310-abi3-win_amd64.whl", hash = "sha256:f78bb2abd00101cbb23cc0cb068f7e36e081057a15d2ec2dde3dda280709f030", size = 51829755, upload-time = "2026-04-22T19:14:50.85Z" },
+    { url = "https://files.pythonhosted.org/packages/65/ad/b33c3022a394f3eb55c3310597cec615412a8a33880055eee191d154a628/polars_runtime_32-1.40.1-cp310-abi3-win_arm64.whl", hash = "sha256:b5cbfaf6b085b420b4bfcbe24e8f665076d1cccfdb80c0484c02a023ce205537", size = 45822104, upload-time = "2026-04-22T19:14:54.192Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`BetaPrior` was hard-coded to unit support, so a beta could only be used
for parameters that happen to live on [0, 1]. That rules it out for the
common case of wanting a smooth prior tapered at the edges over an existing bounded range —
you can currently only express such a range as a uniform, which puts as
much mass at the endpoints as in the middle.

The motivating case was for the generation-interval, e.g., on range [5.4, 10.07]. We
want to keep the range but down-weight the extremes; `beta(3, 3)` over
those bounds cuts the prior sd by 35% and the 95% span to 0.74x of the
uniform, without moving the mean off the range midpoint.

## Changes

`BetaPrior` takes optional `min` and `max`, defaulting to 0.0 and 1.0.
Sampling is `min + (max - min) * rng.beta(alpha, beta)`, and the density
uses `scipy.stats.beta.pdf(..., loc=min, scale=max - min)`, so it
normalises over the stated range and returns exactly 0.0 outside it.
`min >= max` raises `ValueError`.

`load_priors` passes the two keys through when present, and the schema
accepts them as optional numbers — `required` is still `["alpha",
"beta"]`.

## Compatibility

Non-breaking. The defaults reproduce the previous behaviour exactly, and
existing prior files are unaffected since neither key is required.

## Tests

Four new tests: bounded sampling stays within the bounds, bounded density
matches `scipy` with `loc`/`scale` and is 0.0 just outside each bound,
inverted bounds raise, and the schema validates a bounded beta.